### PR TITLE
[FIX] 채팅방 입장 시 캐릭터 정보 로드 api 호출 제거, 1:1 채팅방이면 who to send 모델 건너뛰기

### DIFF
--- a/src/apis/ChatAPICalls.js
+++ b/src/apis/ChatAPICalls.js
@@ -154,22 +154,22 @@ export function deleteHumanQuestions(DeleteUserMessageRequest) {
     }
 }
 
-export function loadChatInfo(requestDataForFastAPI) {
+// export function loadChatInfo(requestDataForFastAPI) {
 
-    console.log('캐릭터 inference에 필요한 데이터 미리 로드하기...');
+//     console.log('캐릭터 inference에 필요한 데이터 미리 로드하기...');
   
-    return async (dispatch, getState) => {
-        try {
-            // 서버에 API 요청
-            const result = await fastAPIrequest('POST', '/load_info', requestDataForFastAPI);
-            console.log('result : ', result); // 서버에서 받아온 data 정보 
+//     return async (dispatch, getState) => {
+//         try {
+//             // 서버에 API 요청
+//             const result = await fastAPIrequest('POST', '/load_info', requestDataForFastAPI);
+//             console.log('result : ', result); // 서버에서 받아온 data 정보 
   
-            return result; // 포장한 데이터를 반환해주기.
-        } catch (error) {
-            console.error('API error:', error);
-        }
-    }
-  }
+//             return result; // 포장한 데이터를 반환해주기.
+//         } catch (error) {
+//             console.error('API error:', error);
+//         }
+//     }
+//   }
 
 // ✨함수 정의 예시✨
 export function allHospitalAPI() {

--- a/src/pages/chat/ChatRoom.js
+++ b/src/pages/chat/ChatRoom.js
@@ -2,7 +2,7 @@ import "../../css/chat.css";
 import React, { useState, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useSearchParams } from "react-router-dom";
-import { deleteHumanQuestions, getMsgImg, loadChatInfo, loadChatRoomInfo, matchCharacter, sendMessageToAI } from "../../apis/ChatAPICalls";
+import { deleteHumanQuestions, getMsgImg, loadChatRoomInfo, matchCharacter, sendMessageToAI } from "../../apis/ChatAPICalls";
 import { request } from "../../apis/Apis";
 import Message from "./Message";
 import voiceButton from "./images/voice.png";
@@ -62,11 +62,11 @@ const ChatRoom = ({ }) => {
     // 채팅방 정보 state(currentRoom) 반영 
     dispatch(loadChatRoomInfo(chatUser.memberNo,sessionId));
 
-    // 현재 채팅방 맴버에게 메시지 전송시 inference에 필요한 데이터 미리 로드시켜주기
-    const requestDataForFastAPI = {
-      char_id_list: charNos
-    }
-    dispatch(loadChatInfo(requestDataForFastAPI))
+    // 현재 채팅방 맴버에게 메시지 전송시 inference에 필요한 데이터 미리 로드시켜주기 => FAST API 실행 시 모든 캐릭터 데이터 로드하는 걸로 변경
+    // const requestDataForFastAPI = {
+    //   char_id_list: charNos
+    // }
+    // dispatch(loadChatInfo(requestDataForFastAPI))
   }, [sessionId]);
 
   // 메시지 전송
@@ -84,7 +84,11 @@ const ChatRoom = ({ }) => {
     }
     console.log("matchCharacterInfo: ",matchCharacterInfo)
     
-    const whoToSend = await dispatch(matchCharacter(matchCharacterInfo));
+    let whoToSend = charNos
+    if (charNos.length > 1) {
+      whoToSend = await dispatch(matchCharacter(matchCharacterInfo));
+    }
+    
     console.log("whoToSend:",whoToSend);
   
     // for문 써서 whoToSend에 담긴 charNo 만큼 메시지 보내기


### PR DESCRIPTION
- FAST API에서 캐릭터 데이터 로드를 init()에서 미리 실행하므로 채팅방 입장 시 캐릭터 정보 로드하는 api 호출 제거
- 1:1 채팅방이면 who to send 모델 건너뛰기